### PR TITLE
Align to MiP_ProMini-Pack connection logic

### DIFF
--- a/src/mip_esp8266.h
+++ b/src/mip_esp8266.h
@@ -516,6 +516,7 @@ public:
 
 protected:
     void    clear();
+    int8_t  attemptMiPConnection(uint32_t baudRate);
 
     void    connect();
 
@@ -575,8 +576,6 @@ protected:
     void    processOobResponseData(uint8_t commandByte);
     uint8_t discardUnexpectedSerialData();
 
-    void    connectAttempt();
-    
     // Bits that can be set in m_flags bitfield.
     enum FlagBits
     {


### PR DESCRIPTION
Revised earlier 115200 and 9600 connection attempts to more closely resemble that found in @adamgreen's commit at [452b172](https://github.com/adamgreen/MiP_ProMini-Pack/commit/452b17206cf08a4869b7f249a99f67b56f2d7d11).

A couple minor differences include naming baud rate constants as absolute rather than relative (MIP_SLOW_BAUD_RATE vs. MIP_SLOWER_BAUD_RATE), and stepping right into a loop of trying 115200 and then 9600 rather than trying 115200 and, if failing, stepping into a loop of 115200 and 9600.  The latter means trying 115200 twice before trying 9600.